### PR TITLE
Feature/handle multiple aps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
+
 # Wireless Signal Monitor
 
 ## Project Description
-A lightweight Python tool (part of a Final Year Project) for collecting and processing wireless signal metrics from AirOS-based Access Points via SSH. It retrieves real-time metrics such as signal, RSSI, noise, and SNR, then formats and displays them for further analysis.
+A lightweight Python tool (part of a Final Year Project) for collecting and processing wireless signal metrics from AirOS-based Access Points via SSH. It retrieves real-time metrics such as signal, RSSI, noise, and SNR, then formats and displays them for further analysis. The script now supports polling **multiple APs** concurrently and filters for stations named **“PowerBeam M5 4”**, aggregating all relevant signal data in a single output line per interval.
 
 ## Installation
 1. **Clone the repository**:
@@ -21,17 +22,28 @@ A lightweight Python tool (part of a Final Year Project) for collecting and proc
    pip install -r requirements.txt
    ```
 
-4. **(Optional)** Adjust SSH settings in `ssh_connector.py` or wherever you store constants (e.g., IP, username, key path).
+4. **(Optional)** Adjust SSH settings in `ssh_connector.py` or wherever you store constants (e.g., IP, username, key path).  
+   You can also add or remove AP entries in `ap_config.py` to update which devices are polled.
 
 ## Usage
+
 1. **Run the main script**:
    ```bash
    python src/main.py
    ```
 
-The script will:
-- Establish an SSH connection to your specified AP.
-- Execute `wstalist` (or a similar command) to pull signal metrics.
-- Parse and display signal, RSSI, noise, and SNR data in real time.
+   By default, the script connects to each AP listed in `ap_config.py`, executes `wstalist`, and prints the aggregated signal data (or None for APs that time out).
+
+2. **Use Simulation Mode**:
+   ```bash
+   python src/main.py --simulation
+   ```
+
+   This mode generates randomized “mock” data, useful for testing without a live network.
+
+### When running:
+- A single line of comma-separated values is printed every interval.
+- Only stations named “PowerBeam M5 4” are parsed, and if multiple such stations appear on an AP, all are listed.
+- If an AP does not respond within the timeout window, its data is marked as None.
 
 Stop the script anytime with `Ctrl + C`.

--- a/src/ap_config.py
+++ b/src/ap_config.py
@@ -1,0 +1,13 @@
+ap_list = [
+    {
+        "host": "192.168.1.21",
+        "username": "ubnt",
+        "ssh_key_path": "~/.ssh/id_rsa"
+    },
+    {
+        "host": "192.168.1.22",
+        "username": "ubnt",
+        "ssh_key_path": "~/.ssh/id_rsa"
+    }
+    # Add more APs as needed
+]

--- a/src/ap_config.py
+++ b/src/ap_config.py
@@ -8,6 +8,12 @@ ap_list = [
         "host": "192.168.1.22",
         "username": "ubnt",
         "ssh_key_path": "~/.ssh/id_rsa"
-    }
+    },
+    {
+        "host": "192.168.1.23",
+        "username": "ubnt",
+        "ssh_key_path": "~/.ssh/id_rsa"
+    },
+
     # Add more APs as needed
 ]

--- a/src/data_parser.py
+++ b/src/data_parser.py
@@ -1,43 +1,57 @@
-def parse_signal_data(all_host_data, offset_seconds):
+def parse_signal_data(all_host_data, offset_seconds, known_hosts):
     """
-    :param all_host_data: list of (host, data) tuples, where data is either None or
-                          a list of station dicts from wstalist.
-    :param offset_seconds: float, time offset since script start.
-    :return: dict: {
-        "time_since_start": offset_seconds,
+    Parse the raw station data from multiple APs and structure it so we know
+    the RSS from APx -> APy plus the noise for each AP.
+
+    :param all_host_data: list of (host, station_list) pairs
+    :param offset_seconds: float, time offset since script start
+    :param known_hosts: set of hosts (IPs) that we expect
+    :return: dict of the form:
+      {
+        "time_since_start": <float>,
         "results": {
-           host1: [ (signal, noise), (signal, noise), ... ] or None,
-           host2: [ (signal, noise), ... ] or None,
-           ...
+          <host1>: {
+            <host2>: <signal_from_host1's perspective_of_host2>,
+            <host3>: <signal>,
+            "noise": <noise_floor_for_host1>
+          },
+          <host2>: None or {
+             ...
+          },
+          ...
         }
-    }
-
-    NOTE: We parse ALL stations with 'name' == "PowerBeam M5 4" for each AP.
-          If data is missing or no station matched, the value is None.
+      }
     """
-
+    # Initialize a dict for each host
     results_dict = {}
+    for (host, _) in all_host_data:
+        results_dict[host] = {}  # will become None if we can't parse
+
     for (host, station_list) in all_host_data:
+        # If we had a timeout or error, station_list is None
         if station_list is None:
-            # Timed out or error => fill with None
             results_dict[host] = None
             continue
 
-        # Filter for "PowerBeam M5 4" stations
-        powerbeam_entries = [s for s in station_list if s.get('name') == "PowerBeam M5 4"]
-        if not powerbeam_entries:
-            # No matching station
-            results_dict[host] = None
-            continue
+        # We'll store one noise floor per AP. If multiple stations appear,
+        # they usually have the same noisefloor. We'll just use the first we see.
+        ap_noise = None
 
-        # Parse every matching station
-        parsed_values = []
-        for entry in powerbeam_entries:
-            signal = entry.get('signal')
-            noise = entry.get('noisefloor')
-            parsed_values.append((signal, noise))
+        # Check each station
+        for station in station_list:
+            # Must match the specific name to be considered
+            if station.get('name') == "PowerBeam M5 4":
+                if ap_noise is None:
+                    ap_noise = station.get('noisefloor')
 
-        results_dict[host] = parsed_values
+                remote_ip = station.get('lastip')
+                if remote_ip in known_hosts:
+                    # We store the signal from this AP's perspective
+                    results_dict[host][remote_ip] = station.get('signal')
+
+        # Record noise for this AP if we didn't mark it None
+        if results_dict[host] is not None:
+            results_dict[host]["noise"] = ap_noise
 
     return {
         "time_since_start": offset_seconds,

--- a/src/data_parser.py
+++ b/src/data_parser.py
@@ -1,29 +1,45 @@
-def parse_signal_data(signal_data, offset_seconds):
+def parse_signal_data(all_host_data, offset_seconds):
     """
-    Parse and format the raw signal data into a readable tuple format.
-    """
-    formatted_data = []
-    if not signal_data:
-        # If None or empty, return a single entry with NULL placeholders
-        return [{
-            'time_since_start': offset_seconds,
-            'signal': None,
-            'rssi': None,
-            'noise': None,
-            'snr': None
-        }]
+    :param all_host_data: list of (host, data) tuples, where data is either None or
+                          a list of station dicts from wstalist.
+    :param offset_seconds: float, time offset since script start.
+    :return: dict: {
+        "time_since_start": offset_seconds,
+        "results": {
+           host1: [ (signal, noise), (signal, noise), ... ] or None,
+           host2: [ (signal, noise), ... ] or None,
+           ...
+        }
+    }
 
-    for entry in signal_data:
-        signal = entry.get('signal')
-        rssi = entry.get('rssi')
-        noise = entry.get('noisefloor')
-        snr = signal - noise if signal is not None and noise is not None else None
-        formatted_data.append({
-            'time_since_start': offset_seconds,
-            'signal': signal,
-            'rssi': rssi,
-            'noise': noise,
-            'snr': snr
-        })
-    return formatted_data
-    pass
+    NOTE: We parse ALL stations with 'name' == "PowerBeam M5 4" for each AP.
+          If data is missing or no station matched, the value is None.
+    """
+
+    results_dict = {}
+    for (host, station_list) in all_host_data:
+        if station_list is None:
+            # Timed out or error => fill with None
+            results_dict[host] = None
+            continue
+
+        # Filter for "PowerBeam M5 4" stations
+        powerbeam_entries = [s for s in station_list if s.get('name') == "PowerBeam M5 4"]
+        if not powerbeam_entries:
+            # No matching station
+            results_dict[host] = None
+            continue
+
+        # Parse every matching station
+        parsed_values = []
+        for entry in powerbeam_entries:
+            signal = entry.get('signal')
+            noise = entry.get('noisefloor')
+            parsed_values.append((signal, noise))
+
+        results_dict[host] = parsed_values
+
+    return {
+        "time_since_start": offset_seconds,
+        "results": results_dict
+    }

--- a/src/data_parser.py
+++ b/src/data_parser.py
@@ -33,8 +33,6 @@ def parse_signal_data(all_host_data, offset_seconds, known_hosts):
             results_dict[host] = None
             continue
 
-        # We'll store one noise floor per AP. If multiple stations appear,
-        # they usually have the same noisefloor. We'll just use the first we see.
         ap_noise = None
 
         # Check each station

--- a/src/data_parser.py
+++ b/src/data_parser.py
@@ -2,25 +2,6 @@ def parse_signal_data(all_host_data, offset_seconds, known_hosts):
     """
     Parse the raw station data from multiple APs and structure it so we know
     the RSS from APx -> APy plus the noise for each AP.
-
-    :param all_host_data: list of (host, station_list) pairs
-    :param offset_seconds: float, time offset since script start
-    :param known_hosts: set of hosts (IPs) that we expect
-    :return: dict of the form:
-      {
-        "time_since_start": <float>,
-        "results": {
-          <host1>: {
-            <host2>: <signal_from_host1's perspective_of_host2>,
-            <host3>: <signal>,
-            "noise": <noise_floor_for_host1>
-          },
-          <host2>: None or {
-             ...
-          },
-          ...
-        }
-      }
     """
     # Initialize a dict for each host
     results_dict = {}
@@ -28,6 +9,7 @@ def parse_signal_data(all_host_data, offset_seconds, known_hosts):
         results_dict[host] = {}  # will become None if we can't parse
 
     for (host, station_list) in all_host_data:
+        # print(f"Parsing data for host: {host}, station_list: {station_list}")  # Debugging statement
         # If we had a timeout or error, station_list is None
         if station_list is None:
             results_dict[host] = None

--- a/src/main.py
+++ b/src/main.py
@@ -3,21 +3,23 @@ import queue
 import threading
 import time
 import sys
-from ssh_connector import connect_to_host, fetch_signal_data
+
+from ap_config import ap_list
+from ssh_connector import fetch_signal_data
+from mock_data_generator import fetch_signal_data_simulation
 from data_parser import parse_signal_data
 from signal_printer import print_signal_data
-from mock_data_generator import fetch_signal_data_simulation
 
 POLL_INTERVAL = 1
 COMMAND_TIMEOUT = 0.8
 
 def parse_arguments():
-    parser = argparse.ArgumentParser(description="Wireless Signal Monitor")
+    parser = argparse.ArgumentParser(description="Wireless Signal Monitor (Multi-AP)")
     parser.add_argument(
         "--simulation",
         "-s",
         action="store_true",
-        help="Enable simulation mode (no SSH connection, generate random data for testing purposes)",
+        help="Enable simulation mode (no SSH connection, generate random data)"
     )
     return parser.parse_args()
 
@@ -25,66 +27,69 @@ def main():
     args = parse_arguments()
     simulation_mode = args.simulation
 
-    if not simulation_mode:
-        # Normal operation: connect via SSH
-        client = connect_to_host(...)
-        if not client:
-            sys.exit("Failed to establish SSH connection. Exiting.")
-    else:
-        # In simulation mode there is no SSH client needed
-        client = None
-
     start_time = time.time()
 
     try:
         while True:
-            # Calculate how many seconds since script started
             offset_seconds = time.time() - start_time
 
-            # Start a thread to fetch data
+            # We'll poll all APs in parallel
             result_queue = queue.Queue()
+            threads = []
 
-            if simulation_mode:
-                # Thread to fetch mock data
-                thread = threading.Thread(
-                    target=fetch_signal_data_simulation,
-                    args=(result_queue,),
-                    daemon=True
-                )
-            else:
-                # Thread to fetch real data
-                thread = threading.Thread(
-                    target=fetch_signal_data,
-                    args=(client, result_queue),
-                    daemon=True
-                )
+            for ap in ap_list:
+                if simulation_mode:
+                    t = threading.Thread(
+                        target=fetch_signal_data_simulation,
+                        args=(ap, result_queue),
+                        daemon=True
+                    )
+                else:
+                    t = threading.Thread(
+                        target=fetch_signal_data,
+                        args=(ap, result_queue),
+                        daemon=True
+                    )
+                threads.append(t)
+                t.start()
 
-            thread.start()
+            # Wait up to COMMAND_TIMEOUT for each thread
+            for t in threads:
+                t.join(COMMAND_TIMEOUT)
+                # If the thread is still alive after join, it won't put anything in queue
+                # so that AP will effectively be data=None
 
-            # Wait for up to COMMAND_TIMEOUT seconds
-            thread.join(COMMAND_TIMEOUT)
+            # Collect all data from the queue
+            all_host_data = []
+            while not result_queue.empty():
+                host, data = result_queue.get()
+                # host is e.g. "192.168.1.21", data is list-of-dicts or None
+                all_host_data.append((host, data))
 
-            if thread.is_alive():
-                # The data wasn't returned in time => fill with NULL
-                signal_data = None
-            else:
-                # If thread is finished then retrieve the data from the queue
-                signal_data = result_queue.get()
+            # If any AP never responded, we won't have it in all_host_data; let's fill it
+            known_hosts = {ap["host"] for ap in ap_list}
+            responded_hosts = {hd[0] for hd in all_host_data}
+            missing_hosts = known_hosts - responded_hosts
+            # For those, push (host, None)
+            for mh in missing_hosts:
+                all_host_data.append((mh, None))
 
-            # Now parse and print
-            parsed_data = parse_signal_data(signal_data, offset_seconds)
-            print_signal_data(parsed_data)
+            # Now parse ALL AP results
+            parsed_output = parse_signal_data(all_host_data, offset_seconds)
 
-            # Sleep to maintain exact intervals from the start of the loop
+            # Print in a single line
+            print_signal_data(parsed_output)
+
+            # Sleep for the remainder of the interval
             loop_end = time.time()
             elapsed = loop_end - (start_time + offset_seconds)
             time_to_sleep = POLL_INTERVAL - elapsed
             if time_to_sleep > 0:
                 time.sleep(time_to_sleep)
-    finally:
-        if client and not simulation_mode:
-            client.close()
 
+    except KeyboardInterrupt:
+        print("\nExiting on user interrupt.")
+        sys.exit(0)
 
 if __name__ == '__main__':
     main()

--- a/src/main.py
+++ b/src/main.py
@@ -10,8 +10,8 @@ from mock_data_generator import fetch_signal_data_simulation
 from data_parser import parse_signal_data
 from signal_printer import print_signal_data
 
-POLL_INTERVAL = 2
-COMMAND_TIMEOUT = 1.8
+POLL_INTERVAL = 0.5
+COMMAND_TIMEOUT = 0.45
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description="Wireless Signal Monitor (Multi-AP)")
@@ -78,6 +78,7 @@ def main():
             threads = []
 
             for ap in used_ap_list:
+                host = ap["host"]
                 if simulation_mode:
                     # Simulation: generate mock data with stations
                     t = threading.Thread(

--- a/src/mock_data_generator.py
+++ b/src/mock_data_generator.py
@@ -92,11 +92,13 @@ def generate_mock_signal_data():
     # Return as a list to mimic real wstalist output for multiple stations
     return [mock_station]
 
-def fetch_signal_data_simulation(result_queue):
+def fetch_signal_data_simulation(ap_config, result_queue):
     """
     Thread target function (simulation mode).
-    Generates random data mimicking 'wstalist' output and puts the result into a queue.
+    Generates random data mimicking 'wstalist' output and puts the result into the queue.
+    We include 'host' for reference or logging if desired.
     """
-    data = generate_mock_signal_data()
-    result_queue.put(data)
+    host = ap_config.get("host", "SIMULATED_AP")
+    data = generate_mock_signal_data()  # one or more stations
+    result_queue.put((host, data))
 

--- a/src/signal_printer.py
+++ b/src/signal_printer.py
@@ -1,15 +1,26 @@
-def print_signal_data(parsed_data):
+def print_signal_data(parsed_output):
     """
-    Print the parsed signal data in a readable format.
+    Prints data in a single line:
+      time_since_start, host1_signal1, host1_noise1, host1_signal2, host1_noise2, ..., hostN_signalX, hostN_noiseX
+    If no data from a host, print None/None.
     """
-    for entry in parsed_data:
-        t_str = f"{entry['time_since_start']:.2f}s"
-        print(
-            f"[{t_str}] "
-            f"Signal: {entry['signal']} dBm, "
-            f"RSSI: {entry['rssi']}, "
-            f"Noise: {entry['noise']} dBm, "
-            f"SNR: {entry['snr']} dB"
-        )
-    print("-" * 40)
-    pass
+
+    time_since_start = parsed_output["time_since_start"]
+    results_dict = parsed_output["results"]  # { host: [ (signal, noise), ... ] or None }
+
+    line_items = [f"{time_since_start:.2f}"]  # start with time
+
+    sorted_hosts = sorted(results_dict.keys())
+
+    for host in sorted_hosts:
+        host_data = results_dict[host]
+        if host_data is None:
+            # means either timed out or no "PowerBeam M5 4" entry
+            line_items.append("None")
+            line_items.append("None")
+        else:
+            for (sig, nos) in host_data:
+                line_items.append(str(sig if sig is not None else "None"))
+                line_items.append(str(nos if nos is not None else "None"))
+
+    print(",".join(line_items))

--- a/src/signal_printer.py
+++ b/src/signal_printer.py
@@ -1,26 +1,61 @@
 def print_signal_data(parsed_output):
     """
-    Prints data in a single line:
-      time_since_start, host1_signal1, host1_noise1, host1_signal2, host1_noise2, ..., hostN_signalX, hostN_noiseX
-    If no data from a host, print None/None.
+    Prints a single line with labels like:
+      Timestamp,
+      RSS(AP2->AP1)=<val>, RSS(AP3->AP1)=<val>, noise(AP1)=<val>,
+      RSS(AP1->AP2)=<val>, RSS(AP3->AP2)=<val>, noise(AP2)=<val>,
+      RSS(AP1->AP3)=<val>, RSS(AP2->AP3)=<val>, noise(AP3)=<val>
+      ...
+    for however many APs are being monitored.
     """
-
     time_since_start = parsed_output["time_since_start"]
-    results_dict = parsed_output["results"]  # { host: [ (signal, noise), ... ] or None }
+    results_dict = parsed_output["results"]
 
-    line_items = [f"{time_since_start:.2f}"]  # start with time
+    # Sort the APs by IP/host for consistent ordering
+    ap_hosts = sorted(results_dict.keys())
 
-    sorted_hosts = sorted(results_dict.keys())
+    # Create a map host -> label, e.g. "192.168.1.21" -> "AP1", etc.
+    label_map = {ap_hosts[i]: f"AP{i + 1}" for i in range(len(ap_hosts))}
 
-    for host in sorted_hosts:
-        host_data = results_dict[host]
-        if host_data is None:
-            # means either timed out or no "PowerBeam M5 4" entry
-            line_items.append("None")
-            line_items.append("None")
-        else:
-            for (sig, nos) in host_data:
-                line_items.append(str(sig if sig is not None else "None"))
-                line_items.append(str(nos if nos is not None else "None"))
+    # Begin the output line with time
+    line_items = [f"{time_since_start:.2f}"]
 
-    print(",".join(line_items))
+    # For each "this_ap", we collect: RSS(other_ap->this_ap) for all other_ap, then noise(this_ap)
+    # So it looks like:
+    #   RSS(AP2->AP1)=..., RSS(AP3->AP1)=..., noise(AP1)=...,
+    #   RSS(AP1->AP2)=..., RSS(AP3->AP2)=..., noise(AP2)=...,
+    #   ...
+    for this_ap in ap_hosts:
+        if results_dict[this_ap] is None:
+            # Means we had no data (timeout or error) => place None for each link + noise
+            for other_ap in ap_hosts:
+                if other_ap != this_ap:
+                    label = f"RSS({label_map[other_ap]}->{label_map[this_ap]})"
+                    line_items.append(f"{label}=None")
+            noise_label = f"noise({label_map[this_ap]})"
+            line_items.append(f"{noise_label}=None")
+            continue
+
+        # For each other_ap
+        for other_ap in ap_hosts:
+            if other_ap == this_ap:
+                continue
+            # If the other_ap result is also None, we can't glean a signal
+            if results_dict[other_ap] is None:
+                signal_val = "None"
+            else:
+                # e.g. results_dict[other_ap].get(this_ap) => RSS from other_ap->this_ap
+                link_signal = results_dict[other_ap].get(this_ap)
+                signal_val = link_signal if link_signal is not None else "None"
+
+            label = f"RSS({label_map[other_ap]}->{label_map[this_ap]})"
+            line_items.append(f"{label}={signal_val}")
+
+        # Finally noise for this AP
+        noise_val = results_dict[this_ap].get("noise")
+        noise_label = f"noise({label_map[this_ap]})"
+        noise_str = noise_val if noise_val is not None else "None"
+        line_items.append(f"{noise_label}={noise_str}")
+
+    # Join all labeled items in one line
+    print(", ".join(line_items))

--- a/src/ssh_connector.py
+++ b/src/ssh_connector.py
@@ -46,22 +46,3 @@ def execute_command(client, command):
         print(f"Error executing command: {e}", file=sys.stderr)
         return None
 
-def fetch_signal_data(ap_config, result_queue):
-    """
-    Thread target function:
-    1) Connects to a single AP using SSH.
-    2) Executes wstalist.
-    3) Puts the retrieved data into result_queue along with the AP's host.
-    """
-    host = ap_config.get("host")
-    username = ap_config.get("username")
-    key_path = ap_config.get("ssh_key_path")
-
-    client = connect_to_host(host, username, key_path)
-    data = None
-    if client:
-        data = execute_command(client, COMMAND)
-        client.close()
-
-    # Put a tuple: (host, data)
-    result_queue.put((host, data))

--- a/src/ssh_connector.py
+++ b/src/ssh_connector.py
@@ -36,12 +36,19 @@ def execute_command(client, command):
     """
     try:
         stdin, stdout, stderr = client.exec_command(command)
-        output = stdout.read().decode('utf-8')
-        error = stderr.read().decode('utf-8')
+        output = stdout.read().decode('utf-8').strip()
+        error = stderr.read().decode('utf-8').strip()
+
         if error:
             print(f"Command error: {error}", file=sys.stderr)
             return None
-        return json.loads(output)
+
+        # Ensure the output is valid JSON
+        try:
+            return json.loads(output)
+        except json.JSONDecodeError as e:
+            print(f"JSON decode error: {e}", file=sys.stderr)
+            return None
     except Exception as e:
         print(f"Error executing command: {e}", file=sys.stderr)
         return None

--- a/src/ssh_connector.py
+++ b/src/ssh_connector.py
@@ -29,7 +29,6 @@ def connect_to_host(host, username, key_path):
     except Exception as e:
         print(f"Error connecting to host {host}: {e}", file=sys.stderr)
         return None
-    pass
 
 def execute_command(client, command):
     """
@@ -39,23 +38,20 @@ def execute_command(client, command):
         stdin, stdout, stderr = client.exec_command(command)
         output = stdout.read().decode('utf-8')
         error = stderr.read().decode('utf-8')
-
         if error:
             print(f"Command error: {error}", file=sys.stderr)
             return None
-
         return json.loads(output)
     except Exception as e:
         print(f"Error executing command: {e}", file=sys.stderr)
         return None
-    pass
 
 def fetch_signal_data(ap_config, result_queue):
     """
     Thread target function:
     1) Connects to a single AP using SSH.
     2) Executes wstalist.
-    3) Puts the retrieved data into result_queue along with the AP's host (for reference).
+    3) Puts the retrieved data into result_queue along with the AP's host.
     """
     host = ap_config.get("host")
     username = ap_config.get("username")


### PR DESCRIPTION
### Pull Request Description

#### Summary
Implemented persistent SSH connections for multi-AP polling, optimizing the script by reusing connections instead of reconnecting for each polling cycle. The stable polling rate improved from 0.5Hz to 2Hz, with potential for 10Hz. However, since the AP signal refresh rate is unknown, increasing the polling frequency offers no clear benefit. Maintaining a moderate rate ensures efficiency without redundancy.

#### Changes
- **Persistent SSH connections**: Established and reused SSH sessions for each AP, eliminating repeated handshakes.
- **Removed `fetch_signal_data`**: Replaced with a new `poll_ssh_connection` function using persistent sessions.
- **SSH client cleanup**: Added proper teardown of SSH connections on script exit.
