### PR TITLE
Feature/save to csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,16 @@
 # Wireless Signal Monitor
 
 ## Project Description
-A lightweight Python tool (part of a Final Year Project) for collecting and processing wireless signal metrics from AirOS-based Access Points via SSH. It retrieves real-time metrics such as signal, RSSI, noise, and SNR, then formats and displays them for further analysis. The script now supports polling **multiple APs** concurrently and filters for stations named **“PowerBeam M5 4”**, aggregating all relevant signal data in a single output line per interval.
+A lightweight Python tool (part of a Final Year Project) for collecting and processing wireless signal metrics from AirOS-based Access Points via SSH. It retrieves real-time metrics such as signal, RSSI, and noise floor, then formats and displays them for further analysis. The script supports:
+
+- Polling multiple APs concurrently in parallel threads.
+- Filtering stations by name (currently “PowerBeam M5 4”).
+- Simulation mode, generating mock data without a live network.
+- Logging each poll’s result (directional RSS and noise for each AP) to a CSV file.
+- Configurable duration so it can stop automatically after N seconds.
 
 ## Installation
+
 1. **Clone the repository**:
    ```bash
    git clone https://github.com/Szymon-Kozak/fyp-signal-monitor.git
@@ -16,6 +23,7 @@ A lightweight Python tool (part of a Final Year Project) for collecting and proc
    python -m venv .venv
    source .venv/bin/activate
    ```
+   *(On Windows, use `.\.venv\Scripts\activate` instead.)*
 
 3. **Install dependencies**:
    ```bash
@@ -23,27 +31,87 @@ A lightweight Python tool (part of a Final Year Project) for collecting and proc
    ```
 
 4. **(Optional)** Adjust SSH settings in `ssh_connector.py` or wherever you store constants (e.g., IP, username, key path).  
-   You can also add or remove AP entries in `ap_config.py` to update which devices are polled.
+   You can also add or remove AP entries in `ap_config.py` to update which devices are polled (e.g., multiple APs).
 
 ## Usage
 
-1. **Run the main script**:
+1. **Basic Run (Real Mode)**  
+   By default, the script connects to every AP in `ap_config.py`, executes `wstalist`, and prints aggregated signal data (or None if APs time out):
    ```bash
    python src/main.py
    ```
 
-   By default, the script connects to each AP listed in `ap_config.py`, executes `wstalist`, and prints the aggregated signal data (or None for APs that time out).
-
-2. **Use Simulation Mode**:
+2. **Simulation Mode**  
+   Use `--simulation` to generate random “mock” data without requiring live APs:
    ```bash
    python src/main.py --simulation
    ```
 
-   This mode generates randomized “mock” data, useful for testing without a live network.
+3. **Limiting Number of APs**  
+   Use `--num-aps N` to poll only the first N APs from `ap_list`:
+   ```bash
+   python src/main.py --num-aps 2
+   ```
 
-### When running:
-- A single line of comma-separated values is printed every interval.
-- Only stations named “PowerBeam M5 4” are parsed, and if multiple such stations appear on an AP, all are listed.
-- If an AP does not respond within the timeout window, its data is marked as None.
+4. **Specifying Script Duration**  
+   Use `--duration <seconds>` to stop automatically after `<seconds>`:
+   ```bash
+   python src/main.py --duration 60
+   ```
 
-Stop the script anytime with `Ctrl + C`.
+5. **Combining Arguments**  
+   Combine multiple arguments. For example:
+   ```bash
+   python src/main.py --simulation --num-aps 2 --duration 30
+   ```
+   This runs in simulation mode, polling only the first 2 APs for 30 seconds.
+
+## CSV Logging
+
+1. **Dynamic Filename**  
+   Each run appends data to (or creates) a CSV file named:
+   ```
+   data_pull_<simulation_or_real>_<num_aps>_<duration>_<polling_rate>.csv
+   ```
+   Example: `data_pull_simulation_2_60_0.5.csv`
+
+2. **Header Format**  
+   If the CSV does not already exist, a header is created:
+   ```
+   time, ap2_ap1_rss, ap3_ap1_rss, ..., ap1_noise, ap1_ap2_rss, ap3_ap2_rss, ..., ap2_noise, ...
+   ```
+   For N APs, there are `N(N-1)` directional RSS columns, `N` noise columns, and a time column.
+
+3. **Appending Data**  
+   Each poll writes a new row with time, RSS values, and noise floors.  
+   Example row for 2 APs (AP1 at .21 and AP2 at .22):
+   ```
+   0.501, RSS(AP2->AP1)=-48, noise(AP1)=-95, RSS(AP1->AP2)=-50, noise(AP2)=-99
+   ```
+
+## Notes & Tips
+
+- **Persistent SSH**: Opens and reuses SSH sessions, reducing overhead.  
+- **Adjust Poll Interval**: Default `POLL_INTERVAL` is 0.5s. Change it in `main.py` as needed.  
+- **Timeouts**: If an AP times out, its data is marked as `None`. Adjust `COMMAND_TIMEOUT` if needed.  
+- **Stopping**: Stop the script anytime with `Ctrl + C`. SSH sessions will close cleanly.  
+- **Data Analysis**: Open the CSV in Excel or load it into Python (e.g., with Pandas) for further analysis.
+
+## Example Commands
+
+1. **Poll All APs, No Time Limit**  
+   ```bash
+   python src/main.py
+   ```
+
+2. **Poll 3 APs for 120 seconds**  
+   ```bash
+   python src/main.py --num-aps 3 --duration 120
+   ```
+
+3. **Simulation Mode, 2 APs, 30 seconds**  
+   ```bash
+   python src/main.py --simulation --num-aps 2 --duration 30
+   ```
+
+Each run produces a CSV file (e.g., `data_pull_simulation_2_30_0.5.csv`) and prints data to the console every half-second. Stop the script anytime with `Ctrl + C`.


### PR DESCRIPTION
### Pull Request Description

#### Summary
Added support for time-based script termination and CSV logging for multi-AP polling. Dynamically generated CSV headers based on the number of polled APs, ensuring each poll appends data to the appropriate file.

#### Changes
- **Added `--duration` argument**: Allows the script to terminate automatically after the specified duration.
- **CSV logging**: Created or appended to a CSV file with a dynamic filename and header structure based on the number of APs, as well as poll duration and execution mode.
- **Dynamic headers**: Generated CSV headers in the format `time, ap2_ap1_rss, ap3_ap1_rss, ap1_noise, ...`.
- **Updated README**: Reflects changes in functionality, including examples for new arguments and CSV logging.
